### PR TITLE
Make Rounded Keyboard compatible with other themes

### DIFF
--- a/Rounded Keyboard/shared.css
+++ b/Rounded Keyboard/shared.css
@@ -3,8 +3,8 @@
 }
 
 .DefaultTheme .virtualkeyboard_KeyboardKey_2KhPX {
-    border-radius: var(--keyboard-rounding-amount);
-    box-shadow: 0px 0px 2.5px #1d1d1dcf;
+    border-radius: var(--keyboard-rounding-amount) !important;
+    box-shadow: 0px 0px 2.5px #1d1d1dcf !important;
     transform: scale(0.98);
 }
 


### PR DESCRIPTION
Adds the `!important` rule to specific declarations to override other themes, so that they can be used in conjuction, without the user needing to manually disable and re-enable this one on every boot to force load it last.